### PR TITLE
Add support for Opengraph meta tags

### DIFF
--- a/app-metadata.html
+++ b/app-metadata.html
@@ -89,6 +89,16 @@ Example:
             // title is a special case
             if (name === 'title') {
               document.title = this.data[name];
+            } else if (name.substring(0, 3) === 'og:') {
+              // re-use any already-created meta-tags if possible
+              if (this._meta.hasOwnProperty(name)) {
+                this._meta[name].content = this.data[name];
+              } else {
+                var m = document.createElement('meta');
+                m.setAttribute('property', name); m.content = this.data[name];
+                document.head.appendChild(m);
+                this._meta[name] = m;
+              }
             } else {
               // re-use any already-created meta-tags if possible
               if (this._meta.hasOwnProperty(name)) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,9 @@
           title: '<app-metadata> polymer element',
           description: 'A Polymer element to manage page meta tags for SEO',
           keywords: 'polymer,element,meta,tags,page,SEO,search engine optimization',
-          robots: 'follow,index'
+          robots: 'follow,index',
+          'og:title': '<app-metadata> polymer element',
+          'og:description': 'A Polymer element to manage page meta tags for Facebook Opengraph'
         };
       }
     </script>

--- a/test/app-metadata.html
+++ b/test/app-metadata.html
@@ -31,7 +31,9 @@
             bubbles: true,
             detail: {
               title: 'Title from event',
-              description: 'Description from event'
+              description: 'Description from event',
+              'og:title': 'Title from data (OpenGraph)',
+              'og:description': 'Description from data (OpenGraph)'
             }
           });
 
@@ -43,17 +45,27 @@
 
           assert.equal(document.title, 'Title from event');
           var d = document.querySelector('meta[name="description"]');
-          assert.equal(d.content, 'Description from event');
+          assert.equal(d.content, 'Description from event');;
+          var ot = document.querySelector('meta[property="og:title"]');
+          assert.equal(ot.content, 'Title from data (OpenGraph)');
+          var od = document.querySelector('meta[property="og:description"]');
+          assert.equal(od.content, 'Description from data (OpenGraph)');
         });
 
         test('setting meta data', function() {
           meta.data = {
             title: 'Title from data',
-            description: 'Description from data'
+            description: 'Description from data',
+            'og:title': 'Title from data (OpenGraph)',
+            'og:description': 'Description from data (OpenGraph)'
           };
           assert.equal(document.title, 'Title from data');
           var d = document.querySelector('meta[name="description"]');
           assert.equal(d.content, 'Description from data');
+          var ot = document.querySelector('meta[property="og:title"]');
+          assert.equal(ot.content, 'Title from data (OpenGraph)');
+          var od = document.querySelector('meta[property="og:description"]');
+          assert.equal(od.content, 'Description from data (OpenGraph)');
         });
 
       });

--- a/test/app-metadata.html
+++ b/test/app-metadata.html
@@ -32,8 +32,8 @@
             detail: {
               title: 'Title from event',
               description: 'Description from event',
-              'og:title': 'Title from data (OpenGraph)',
-              'og:description': 'Description from data (OpenGraph)'
+              'og:title': 'Title from event (OpenGraph)',
+              'og:description': 'Description from event (OpenGraph)'
             }
           });
 
@@ -47,9 +47,9 @@
           var d = document.querySelector('meta[name="description"]');
           assert.equal(d.content, 'Description from event');;
           var ot = document.querySelector('meta[property="og:title"]');
-          assert.equal(ot.content, 'Title from data (OpenGraph)');
+          assert.equal(ot.content, 'Title from event (OpenGraph)');
           var od = document.querySelector('meta[property="og:description"]');
-          assert.equal(od.content, 'Description from data (OpenGraph)');
+          assert.equal(od.content, 'Description from event (OpenGraph)');
         });
 
         test('setting meta data', function() {


### PR DESCRIPTION
Adding support for OpenGraph (Facebook) meta tags, which are ' < meta property="...." content="....."  >' instead of '< meta name="...." content="....." >'.

Facebook cannot read them directly (it's not executing Javascript) but it could be usefull if using services like prerender.io.
